### PR TITLE
fix: Accept `Yes` in a case insensitve manner

### DIFF
--- a/new-skeleton.js
+++ b/new-skeleton.js
@@ -27,9 +27,10 @@ function YorN (prompt, yes, no) {
   process.stdin.setEncoding('utf8');
   console.log(prompt);
   var listener = function (text) {
+    const choice = text.toLowerCase();
     process.stdin.removeAllListeners('data');
     process.stdin.pause();
-    if (text == 'y\n') { yes(); }
+    if (choice == 'y\n') { yes(); }
     else { no(); }
   }
   process.stdin.on('data', listener);


### PR DESCRIPTION
This accepts the command line options in a case sensitive manner to help in the following scenario

[![asciicast](https://asciinema.org/a/zeL4zP5mdbosXbwy59cCMZtVh.png)](https://asciinema.org/a/zeL4zP5mdbosXbwy59cCMZtVh)